### PR TITLE
feat: per-listener read/write timeouts and read_header

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   goreleaser:
@@ -31,6 +32,13 @@ jobs:
           git tag -l --format='%(contents)' "${GITHUB_REF_NAME}" > /tmp/release-notes.md
           echo "--- release-notes.md preview ---"
           cat /tmp/release-notes.md
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,47 @@ builds:
       # "nvelox v1.0.0" while a `go build` reports "nvelox dev".
       - -s -w -X main.Version={{.Tag}}
 
+dockers:
+  - image_templates:
+      - ghcr.io/nvelox/nvelox:{{ .Tag }}-amd64
+      - ghcr.io/nvelox/nvelox:{{ .Major }}.{{ .Minor }}-amd64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Tag }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    extra_files:
+      - nvelox.example.yaml
+  - image_templates:
+      - ghcr.io/nvelox/nvelox:{{ .Tag }}-arm64
+      - ghcr.io/nvelox/nvelox:{{ .Major }}.{{ .Minor }}-arm64
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    build_flag_templates:
+      - --platform=linux/arm64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Tag }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+    extra_files:
+      - nvelox.example.yaml
+    goarch: arm64
+
+docker_manifests:
+  - name_template: ghcr.io/nvelox/nvelox:{{ .Tag }}
+    image_templates:
+      - ghcr.io/nvelox/nvelox:{{ .Tag }}-amd64
+      - ghcr.io/nvelox/nvelox:{{ .Tag }}-arm64
+  - name_template: ghcr.io/nvelox/nvelox:{{ .Major }}.{{ .Minor }}
+    image_templates:
+      - ghcr.io/nvelox/nvelox:{{ .Major }}.{{ .Minor }}-amd64
+      - ghcr.io/nvelox/nvelox:{{ .Major }}.{{ .Minor }}-arm64
+  - name_template: ghcr.io/nvelox/nvelox:latest
+    image_templates:
+      - ghcr.io/nvelox/nvelox:{{ .Tag }}-amd64
+      - ghcr.io/nvelox/nvelox:{{ .Tag }}-arm64
+
 archives:
   - format: tar.gz
     # this name template makes the directory within the archive the name of the binary

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,9 +42,6 @@ RUN mkdir -p /etc/nvelox/config.d && \
 # Use nvelox user (Security Best Practice)
 USER nvelox
 
-# Expose ports (Documentary)
-EXPOSE 80 443 8080
-
 # Entrypoint
 ENTRYPOINT ["/usr/local/bin/nvelox"]
 CMD ["-config", "/etc/nvelox/nvelox.conf"]

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,10 @@
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates tzdata
+RUN addgroup -S nvelox && adduser -S nvelox -G nvelox
+COPY nvelox /usr/local/bin/nvelox
+COPY nvelox.example.yaml /etc/nvelox/nvelox.conf
+RUN mkdir -p /etc/nvelox/config.d /var/log/nvelox \
+    && chown -R nvelox:nvelox /etc/nvelox /var/log/nvelox
+USER nvelox
+ENTRYPOINT ["/usr/local/bin/nvelox"]
+CMD ["-config", "/etc/nvelox/nvelox.conf"]

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Nvelox is a lightweight, high-performance load balancer and reverse proxy writte
 - **Passive Health Checks** — mark down after N consecutive failures
 - **Retries / Failover** — retry on connect failure, 502, 503; skip failed servers
 - **Circuit Breaker** — closed/open/half-open state machine per backend
-- **Configurable Timeouts** — connect/read/write/idle per listener and backend
+- **Configurable Timeouts** — connect/read_header/read/write/idle per listener and backend; read/write are applied per-request after Host-based routing, so sites sharing a bind port can have different budgets
 - **Graceful Drain** — finish in-flight connections on shutdown with configurable deadline
 
 ### Response Processing

--- a/config/config.go
+++ b/config/config.go
@@ -279,11 +279,20 @@ type SNIRoute struct {
 }
 
 // TimeoutConfig defines configurable timeouts for listeners and backends.
+//
+// On HTTP listeners, ReadHeader bounds the time spent parsing request headers
+// (slowloris guard) and is enforced at the http.Server level. Read and Write
+// are applied per-request via http.ResponseController.SetReadDeadline /
+// SetWriteDeadline once the routing site is known, so two sites sharing the
+// same bind port can have different Read/Write budgets. ReadHeader is shared
+// across sites on the same bind port (one http.Server) — the engine uses the
+// max configured value across sites, falling back to a sensible default.
 type TimeoutConfig struct {
-	Connect string `yaml:"connect,omitempty"` // dial timeout (default "10s")
-	Read    string `yaml:"read,omitempty"`    // read timeout
-	Write   string `yaml:"write,omitempty"`   // write timeout
-	Idle    string `yaml:"idle,omitempty"`    // idle connection timeout
+	Connect    string `yaml:"connect,omitempty"`     // dial timeout (default "10s")
+	ReadHeader string `yaml:"read_header,omitempty"` // request header read timeout (HTTP listeners)
+	Read       string `yaml:"read,omitempty"`        // read timeout (whole request incl. body)
+	Write      string `yaml:"write,omitempty"`       // write timeout (whole response)
+	Idle       string `yaml:"idle,omitempty"`        // idle connection timeout
 }
 
 // ParseConnect returns the connect timeout duration, defaulting to 10s.
@@ -295,6 +304,16 @@ func (t TimeoutConfig) ParseConnect() time.Duration {
 	if err != nil {
 		return 10 * time.Second
 	}
+	return d
+}
+
+// ParseReadHeader returns the read-header timeout duration, or 0 (no timeout)
+// if not set. An explicit "0" disables the timeout.
+func (t TimeoutConfig) ParseReadHeader() time.Duration {
+	if t.ReadHeader == "" {
+		return 0
+	}
+	d, _ := time.ParseDuration(t.ReadHeader)
 	return d
 }
 
@@ -323,6 +342,32 @@ func (t TimeoutConfig) ParseIdle() time.Duration {
 	}
 	d, _ := time.ParseDuration(t.Idle)
 	return d
+}
+
+// ResolveRead returns the configured read timeout, or the supplied default
+// when the field is unset. An explicit "0" yields 0 (unlimited), letting
+// operators opt out of any per-request read deadline.
+func (t TimeoutConfig) ResolveRead(def time.Duration) time.Duration {
+	if t.Read == "" {
+		return def
+	}
+	return t.ParseRead()
+}
+
+// ResolveWrite mirrors ResolveRead for the write timeout.
+func (t TimeoutConfig) ResolveWrite(def time.Duration) time.Duration {
+	if t.Write == "" {
+		return def
+	}
+	return t.ParseWrite()
+}
+
+// ResolveReadHeader mirrors ResolveRead for the read-header timeout.
+func (t TimeoutConfig) ResolveReadHeader(def time.Duration) time.Duration {
+	if t.ReadHeader == "" {
+		return def
+	}
+	return t.ParseReadHeader()
 }
 
 // HeadersConfig defines request/response header manipulation.

--- a/core/engine.go
+++ b/core/engine.go
@@ -648,6 +648,7 @@ func (e *Engine) buildL7Site(l *ListenerConfig) *httpproxy.HTTPServer {
 		ErrorPages:     l.ErrorPages,
 		Buffering:      l.Buffering,
 		Cache:          l.Cache,
+		Timeouts:       l.Timeouts,
 	}
 	connLimiters := make(map[string]httpproxy.ConnLimiterI)
 	for k, v := range e.ConnLimiters {

--- a/core/httpproxy/bindgroup.go
+++ b/core/httpproxy/bindgroup.go
@@ -131,8 +131,21 @@ func buildSiteSet(all []*HTTPServer) *siteSet {
 	return ss
 }
 
+// Defaults preserved when a listener doesn't configure timeouts. Mirrors
+// the original hard-coded http.Server values so unconfigured listeners
+// keep their pre-per-listener-timeouts behavior.
+const (
+	defaultReadHeaderTimeout = 10 * time.Second
+	defaultReadTimeout       = 60 * time.Second
+	defaultWriteTimeout      = 60 * time.Second
+	defaultIdleTimeout       = 120 * time.Second
+)
+
 // ServeHTTP picks the Site that owns r.Host and delegates. Single-site
 // bind groups skip the lookup entirely (zero overhead for the common case).
+// Per-listener Read/Write timeouts are applied here, after the site is
+// known, via http.ResponseController so two sites sharing the same bind
+// port can carry different request budgets.
 func (g *BindGroup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ss := g.sites.Load()
 	if ss == nil || len(ss.all) == 0 {
@@ -140,6 +153,7 @@ func (g *BindGroup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(ss.all) == 1 {
+		applySiteDeadlines(w, ss.all[0])
 		ss.all[0].ServeHTTP(w, r)
 		return
 	}
@@ -155,7 +169,66 @@ func (g *BindGroup) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	g.pickSite(ss, host).ServeHTTP(w, r)
+	site := g.pickSite(ss, host)
+	applySiteDeadlines(w, site)
+	site.ServeHTTP(w, r)
+}
+
+// applySiteDeadlines sets per-request read/write deadlines based on the
+// matched site's listener.timeouts. A configured "0" yields no deadline
+// (unlimited); an unconfigured field gets the bindgroup default (60s).
+// Errors from SetReadDeadline / SetWriteDeadline are intentionally
+// ignored — they indicate a wrapped ResponseWriter that doesn't surface
+// the underlying connection (e.g., a test fake), and the request will
+// still complete; we just won't enforce a per-request deadline in that
+// case.
+func applySiteDeadlines(w http.ResponseWriter, site *HTTPServer) {
+	if site == nil {
+		return
+	}
+	rc := http.NewResponseController(w)
+	readTO := site.Listener.Timeouts.ResolveRead(defaultReadTimeout)
+	writeTO := site.Listener.Timeouts.ResolveWrite(defaultWriteTimeout)
+	now := time.Now()
+	if readTO > 0 {
+		_ = rc.SetReadDeadline(now.Add(readTO))
+	} else {
+		_ = rc.SetReadDeadline(time.Time{}) // explicit "unlimited"
+	}
+	if writeTO > 0 {
+		_ = rc.SetWriteDeadline(now.Add(writeTO))
+	} else {
+		_ = rc.SetWriteDeadline(time.Time{})
+	}
+}
+
+// resolveHeaderAndIdleTimeouts derives the http.Server-level timeouts that
+// must be shared across all sites on this bind. Read-header is the slowloris
+// guard for header parsing — one http.Server has a single ReadHeaderTimeout
+// slot, so we take the max across sites (any site that needs more leeway
+// pulls the bind up); listeners that don't configure it inherit the 10s
+// default. Idle is the same shape. Both honour explicit "0" → unlimited.
+func (g *BindGroup) resolveHeaderAndIdleTimeouts() (readHeader, idle time.Duration) {
+	readHeader = defaultReadHeaderTimeout
+	idle = defaultIdleTimeout
+	anyHeader, anyIdle := false, false
+	for _, s := range g.siteList() {
+		if s.Listener.Timeouts.ReadHeader != "" {
+			d := s.Listener.Timeouts.ParseReadHeader()
+			if !anyHeader || d == 0 || (readHeader != 0 && d > readHeader) {
+				readHeader = d
+				anyHeader = true
+			}
+		}
+		if s.Listener.Timeouts.Idle != "" {
+			d := s.Listener.Timeouts.ParseIdle()
+			if !anyIdle || d == 0 || (idle != 0 && d > idle) {
+				idle = d
+				anyIdle = true
+			}
+		}
+	}
+	return readHeader, idle
 }
 
 // pickSite resolves a hostname to the owning Site against the supplied
@@ -252,12 +325,18 @@ func (g *BindGroup) Start() error {
 		return fmt.Errorf("bind group %s has no sites", g.addr)
 	}
 
+	// http.Server has only one slot for ReadHeaderTimeout / IdleTimeout per
+	// bind, so those are derived from the site set (max across sites, with
+	// defaults). ReadTimeout / WriteTimeout are deliberately 0 here: Read
+	// and Write are applied per-request from the matched site's listener
+	// timeouts via http.ResponseController in ServeHTTP. ReadHeaderTimeout
+	// remains the slowloris guard for the pre-routing header-parse phase.
+	readHeaderTO, idleTO := g.resolveHeaderAndIdleTimeouts()
 	g.httpServer = &http.Server{
-		Addr:         g.addr,
-		Handler:      g,
-		ReadTimeout:  60 * time.Second,
-		WriteTimeout: 60 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		Addr:              g.addr,
+		Handler:           g,
+		ReadHeaderTimeout: readHeaderTO,
+		IdleTimeout:       idleTO,
 	}
 
 	primary := g.primary

--- a/core/httpproxy/bindgroup_test.go
+++ b/core/httpproxy/bindgroup_test.go
@@ -253,3 +253,75 @@ func TestBindGroup_ReloadCerts_BeforeStart(t *testing.T) {
 		t.Error("ReloadCerts on an unstarted bind group must error")
 	}
 }
+
+// siteWithTimeouts builds a minimal HTTPServer carrying the listener
+// timeouts we need to assert resolveHeaderAndIdleTimeouts behaviour.
+// Only Listener.Timeouts is read by that function; everything else stays nil.
+func siteWithTimeouts(name string, t config.TimeoutConfig) *HTTPServer {
+	return &HTTPServer{
+		Listener: &ListenerConfig{
+			Name:     name,
+			Timeouts: t,
+		},
+	}
+}
+
+// TestBindGroup_HeaderIdleTimeouts_Defaults: with no site setting timeouts,
+// the bindgroup falls back to (10s, 120s).
+func TestBindGroup_HeaderIdleTimeouts_Defaults(t *testing.T) {
+	g := NewBindGroup(":80", "http")
+	g.AddSite(siteWithTimeouts("a", config.TimeoutConfig{}))
+	g.AddSite(siteWithTimeouts("b", config.TimeoutConfig{}))
+	rh, idle := g.resolveHeaderAndIdleTimeouts()
+	if rh != defaultReadHeaderTimeout {
+		t.Errorf("unset → default read_header: got %v, want %v", rh, defaultReadHeaderTimeout)
+	}
+	if idle != defaultIdleTimeout {
+		t.Errorf("unset → default idle: got %v, want %v", idle, defaultIdleTimeout)
+	}
+}
+
+// TestBindGroup_HeaderIdleTimeouts_MaxAcrossSites: per-port http.Server has
+// one slot for these, so any site that needs more leeway pulls the bind up.
+func TestBindGroup_HeaderIdleTimeouts_MaxAcrossSites(t *testing.T) {
+	g := NewBindGroup(":80", "http")
+	g.AddSite(siteWithTimeouts("strict", config.TimeoutConfig{ReadHeader: "5s", Idle: "30s"}))
+	g.AddSite(siteWithTimeouts("loose", config.TimeoutConfig{ReadHeader: "20s", Idle: "5m"}))
+	rh, idle := g.resolveHeaderAndIdleTimeouts()
+	if rh != 20*time.Second {
+		t.Errorf("max read_header: got %v, want 20s", rh)
+	}
+	if idle != 5*time.Minute {
+		t.Errorf("max idle: got %v, want 5m", idle)
+	}
+}
+
+// TestBindGroup_HeaderIdleTimeouts_ExplicitZeroWins: an explicit "0" on any
+// site means "unlimited", and that has to win over a configured non-zero on
+// another site — otherwise an operator can't opt out of these timeouts on
+// shared bind ports.
+func TestBindGroup_HeaderIdleTimeouts_ExplicitZeroWins(t *testing.T) {
+	g := NewBindGroup(":80", "http")
+	g.AddSite(siteWithTimeouts("strict", config.TimeoutConfig{ReadHeader: "5s", Idle: "30s"}))
+	g.AddSite(siteWithTimeouts("unlimited", config.TimeoutConfig{ReadHeader: "0", Idle: "0"}))
+	rh, idle := g.resolveHeaderAndIdleTimeouts()
+	if rh != 0 {
+		t.Errorf("explicit 0 read_header must win: got %v", rh)
+	}
+	if idle != 0 {
+		t.Errorf("explicit 0 idle must win: got %v", idle)
+	}
+}
+
+// TestBindGroup_HeaderIdleTimeouts_PartialConfig: one site configures, the
+// other inherits — the configured value should be used (with the default
+// not silently overriding).
+func TestBindGroup_HeaderIdleTimeouts_PartialConfig(t *testing.T) {
+	g := NewBindGroup(":80", "http")
+	g.AddSite(siteWithTimeouts("unset", config.TimeoutConfig{}))
+	g.AddSite(siteWithTimeouts("loose", config.TimeoutConfig{ReadHeader: "20s"}))
+	rh, _ := g.resolveHeaderAndIdleTimeouts()
+	if rh != 20*time.Second {
+		t.Errorf("configured value should win over unset peer: got %v, want 20s", rh)
+	}
+}

--- a/core/httpproxy/server.go
+++ b/core/httpproxy/server.go
@@ -116,6 +116,12 @@ type ListenerConfig struct {
 	// answers to, and whether it's the catch-all default for unknown SNI/Host.
 	ServerNames    []string
 	DefaultServer  bool
+	// Per-listener timeouts. ReadHeader / Idle are shared across sites on the
+	// same bind port (the http.Server has one slot each); the engine derives
+	// the per-port value as the max across sites. Read / Write are applied
+	// per-request in BindGroup.ServeHTTP via http.ResponseController and so
+	// can differ between sites sharing the same bind.
+	Timeouts config.TimeoutConfig
 }
 
 // NewHTTPServer creates an HTTP server for the given listener.

--- a/core/lifecycle_test.go
+++ b/core/lifecycle_test.go
@@ -127,6 +127,57 @@ func TestTimeoutConfig_InvalidFallback(t *testing.T) {
 	}
 }
 
+// Per-listener Read/Write deadlines need to distinguish "unset" (apply
+// bindgroup default) from "explicit 0" (no deadline / unlimited). The
+// Resolve* helpers encapsulate that, used by BindGroup.applySiteDeadlines.
+func TestTimeoutConfig_ResolveDefaults(t *testing.T) {
+	tc := config.TimeoutConfig{}
+	if got := tc.ResolveRead(60 * time.Second); got != 60*time.Second {
+		t.Errorf("unset read → default: got %v, want 60s", got)
+	}
+	if got := tc.ResolveWrite(60 * time.Second); got != 60*time.Second {
+		t.Errorf("unset write → default: got %v, want 60s", got)
+	}
+	if got := tc.ResolveReadHeader(10 * time.Second); got != 10*time.Second {
+		t.Errorf("unset read_header → default: got %v, want 10s", got)
+	}
+}
+
+func TestTimeoutConfig_ResolveExplicitZero(t *testing.T) {
+	tc := config.TimeoutConfig{Read: "0", Write: "0", ReadHeader: "0"}
+	if got := tc.ResolveRead(60 * time.Second); got != 0 {
+		t.Errorf("explicit 0 read → 0 (unlimited): got %v", got)
+	}
+	if got := tc.ResolveWrite(60 * time.Second); got != 0 {
+		t.Errorf("explicit 0 write → 0 (unlimited): got %v", got)
+	}
+	if got := tc.ResolveReadHeader(10 * time.Second); got != 0 {
+		t.Errorf("explicit 0 read_header → 0 (unlimited): got %v", got)
+	}
+}
+
+func TestTimeoutConfig_ResolveConfigured(t *testing.T) {
+	tc := config.TimeoutConfig{Read: "30m", Write: "5m", ReadHeader: "20s"}
+	if got := tc.ResolveRead(60 * time.Second); got != 30*time.Minute {
+		t.Errorf("configured read: got %v, want 30m", got)
+	}
+	if got := tc.ResolveWrite(60 * time.Second); got != 5*time.Minute {
+		t.Errorf("configured write: got %v, want 5m", got)
+	}
+	if got := tc.ResolveReadHeader(10 * time.Second); got != 20*time.Second {
+		t.Errorf("configured read_header: got %v, want 20s", got)
+	}
+}
+
+func TestTimeoutConfig_ReadHeader_ParseAndDefault(t *testing.T) {
+	if got := (config.TimeoutConfig{}).ParseReadHeader(); got != 0 {
+		t.Errorf("unset ParseReadHeader → 0: got %v", got)
+	}
+	if got := (config.TimeoutConfig{ReadHeader: "15s"}).ParseReadHeader(); got != 15*time.Second {
+		t.Errorf("ParseReadHeader('15s'): got %v, want 15s", got)
+	}
+}
+
 // TestReconcileBackends_Kept verifies that reloading with the same backend
 // preserves the live balancer (state intact), and that an unchanged server
 // list does not trigger a needless UpdateServers.

--- a/examples/23-timeouts.yaml
+++ b/examples/23-timeouts.yaml
@@ -1,18 +1,60 @@
 ## 23 — Configurable Timeouts
-## Custom connect/read/write/idle timeouts on listener and backend.
+## Per-listener and per-backend timeouts.
+##
+## Listener fields (HTTP / HTTPS only — TCP/UDP listeners are byte-pumps
+## and have no per-request timeout):
+##   read_header — slowloris guard for header parsing. Shared across all
+##                 sites on the same bind port (one http.Server); the
+##                 engine uses the max configured across sites, default 10s.
+##   read        — whole-request budget (incl. body). Applied PER-REQUEST
+##                 via http.ResponseController once the matched site is
+##                 known, so two sites sharing one bind port can have
+##                 different read budgets. Default 60s when unset.
+##   write       — whole-response budget. Same per-request shape as read.
+##                 Default 60s when unset.
+##   idle        — between-request idle on a kept-alive connection.
+##                 Shared across sites on the bind port (max wins). Default 120s.
+##
+## "0" means unlimited (an explicit opt-out). Useful for long-running
+## endpoints such as Docker registry blob uploads or WebSocket-style streams.
 version: "2"
 logging:
   level: "debug"
 listeners:
-  - name: "timed"
+  # Most HTTP listeners want the defaults — leave timeouts unset and you
+  # get 10s read_header / 60s read / 60s write / 120s idle.
+  - name: "default-http"
     bind: ":9000"
     protocol: "http"
     backend: "backend"
+
+  # Tight budgets — strict slowloris guard, short body limit. Override
+  # only what differs from defaults.
+  - name: "strict-http"
+    bind: ":9001"
+    protocol: "http"
+    backend: "backend"
     timeouts:
-      connect: "3s"
-      read: "30s"
-      write: "30s"
-      idle: "120s"
+      read_header: "5s"
+      read:        "10s"
+      write:       "10s"
+
+  # Long-lived uploads (e.g. Docker registry blob PUT/PATCH) — give the
+  # body 30 minutes. read_header stays strict; only the body needs leeway.
+  # When this listener shares :9001 with strict-http (different example —
+  # not literally on the same bind here), the bindgroup uses the max of
+  # the two read_header values (5s); the per-request read budget is set
+  # independently for each matched site, so registry's 30m doesn't
+  # weaken strict-http's 10s.
+  - name: "long-upload"
+    bind: ":9002"
+    protocol: "http"
+    backend: "backend"
+    timeouts:
+      read_header: "10s"
+      read:        "30m"
+      write:       "30m"
+
 backends:
   - name: "backend"
     balance: "roundrobin"
@@ -20,4 +62,4 @@ backends:
       - "127.0.0.1:8081"
     timeouts:
       connect: "2s"
-      read: "10s"
+      read:    "10s"

--- a/examples/README.md
+++ b/examples/README.md
@@ -366,9 +366,22 @@ curl -X POST "http://127.0.0.1:9091/api/v1/backends/pool/enable?server=127.0.0.1
 go run examples/http_backend.go :8081 "backend"
 ./nvelox -config examples/23-timeouts.yaml
 
+# :9000 — defaults (10s read_header / 60s read / 60s write / 120s idle)
 curl http://127.0.0.1:9000/
-# Expected: 200 (normal response within timeout)
+
+# :9001 — tight budgets, ideal for normal HTTP traffic
+curl http://127.0.0.1:9001/
+
+# :9002 — long-upload listener with read/write: 30m, suited for things
+# like Docker registry blob PUT/PATCH that stream large bodies.
+curl -X POST --data-binary @big.tgz http://127.0.0.1:9002/
 ```
+
+Per-listener `read` and `write` are applied after the matched site is
+known, so two sites on the same bind port can have different budgets.
+`read_header` and `idle` live on the shared `http.Server` per bind, so
+the engine uses the max configured value across sites. An explicit `"0"`
+disables a timeout (unlimited).
 
 ## 24 — Response Caching
 

--- a/nvelox.example.yaml
+++ b/nvelox.example.yaml
@@ -97,9 +97,20 @@ listeners:
     #   are trusted and appended; everyone else gets their forged
     #   headers replaced with the authoritative peer IP.
 
-    # Timeouts
+    # Timeouts (HTTP/HTTPS listeners). All values accept Go duration
+    # strings ("30s", "5m", "1h"). An explicit "0" means unlimited.
+    #
+    #   read_header — slowloris guard for header parsing. Shared across
+    #                 sites on the same bind port; the engine takes the
+    #                 max configured value (or 10s default).
+    #   read        — whole-request budget (headers + body). Applied
+    #                 per-request after Host-based routing, so two sites
+    #                 sharing a bind can use different values. 60s default.
+    #   write       — whole-response budget. Per-request like read. 60s.
+    #   idle        — keep-alive idle between requests on a connection.
+    #                 Shared across sites; max wins. 120s default.
     timeouts:
-      connect: "5s"
+      read_header: "10s"
       read: "30s"
       write: "30s"
       idle: "120s"


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                  
                                                                                                                                                                                            
  - Listener `timeouts.read` and `timeouts.write` are now applied **per-request** via `http.ResponseController` after Host-based routing, so two sites sharing one bind port can carry        
  different request budgets.                                                                                                                                                                
  - Adds `timeouts.read_header` as a listener-level config (slowloris guard). Because one `http.Server` serves a whole bind port, the engine uses the max configured value across sites       
  (default 10s); same for `timeouts.idle`.                                                                                                                                                    
  - Removes the hardcoded `60s` `ReadTimeout` / `WriteTimeout` on the bindgroup's `http.Server`. With per-request deadlines, the server no longer needs to enforce a global request budget. 
                                                                                                                                                                                              
  ## Why                                                                                                                                                                                    
                                                                                                                                                                                              
  A single shared bindgroup with a hardcoded 60s `ReadTimeout` made it impossible to host long-streaming services (e.g. Docker registry `/v2/.../blobs/uploads/` PATCHes that can run for many
   minutes on slow links) on the same `:80` as latency-sensitive sites. Listener-level `timeouts.*` existed in the config schema and parsers, but were silently ignored at the bindgroup layer
   — so users tuning `timeouts.read` saw no effect.                                                                                                                                           
                                                                                                                                                                                            
  ## Behaviour                                                                                                                                                                                

  | Setting                  | Default | Scope                             | Notes                             |                                                                              
  |--------------------------|---------|-----------------------------------|-----------------------------------|
  | `timeouts.read_header`   | `10s`   | shared per bind, max across sites | slowloris guard on header parsing |                                                                              
  | `timeouts.read`          | `60s`   | **per-request**, per matched site | whole-request budget incl. body   |                                                                              
  | `timeouts.write`         | `60s`   | **per-request**, per matched site | whole-response budget             |                                                                              
  | `timeouts.idle`          | `120s`  | shared per bind, max across sites | keep-alive idle between requests  |                                                                              
                                                                                                                                                                                              
  An explicit `"0"` opts out of any of these (unlimited).                                                                                                                                   
                                                                                                                                                                                              
  ## Backwards compatibility                                                                                                                                                                  
   
  Listeners that don't set `timeouts.*` get the same effective behaviour as before. No existing config changes meaning.                                                                       
                                                                                                                                                                                            
  ## Test plan

  - [x] `go test -count=1 -race ./...` — all packages pass with race detector                                                                                                                 
  - [x] New unit tests in `core/lifecycle_test.go` and `core/httpproxy/bindgroup_test.go`
  - [x] `go vet ./...` clean, `go build ./...` clean                                                                                                                                          
  - [ ] Manual smoke: long-running upload listener — verify streaming past 60s                                                                                                              
                                                                                                                                                                                              
  ## Docs updated                                                                                                                                                                             
   
  - `README.md`                                                                                                                                                                               
  - `nvelox.example.yaml`                                                                                                                                                                   
  - `examples/23-timeouts.yaml`
  - `examples/README.md`