### PR TITLE
feat(logging): per-connection L4 (TCP/UDP) access log for edge abuse …

### DIFF
--- a/core/handler.go
+++ b/core/handler.go
@@ -181,15 +181,18 @@ func (h *ProxyEventHandler) l4Denied(addr net.Addr, peerTrusted bool) bool {
 }
 
 // closeOnOpen closes a connection being REJECTED from OnOpen (rate-limit or
-// denylist). It must NOT call c.Close() directly: nbio's addConn calls OnOpen and
-// only AFTER it returns registers the fd with the poller (addRead). Closing the
-// fd synchronously inside OnOpen makes that addRead fail with EBADF ("addConn
-// failed: bad file descriptor") and, under fd reuse, can orphan a reused fd — a
-// leaked connection that never gets served and lingers until timeout. Conn.Execute
-// defers the close onto the engine job pool, which runs after addConn has finished
-// — the nbio-intended pattern for post-callback work on a connection.
+// denylist). It must NOT close synchronously: nbio's addConn calls OnOpen and
+// only AFTER it returns registers the fd with the poller (addRead). A synchronous
+// close makes that addRead fail with EBADF ("addConn [fd] failed: bad file
+// descriptor") and, under fd reuse, orphans the reused fd — a leaked connection
+// that lingers until timeout. Conn.Execute is NOT a fix here: nvelox runs nbio
+// with the default (inline) Engine.Execute, which runs the job synchronously in
+// place. A real goroutine is genuinely deferred — OnOpen returns and addConn
+// finishes registering the fd (nanoseconds) long before the Go scheduler can
+// dispatch this goroutine, so addRead always succeeds and the close then runs
+// through nbio's normal, fd-registered path.
 func closeOnOpen(c *nbio.Conn) {
-	c.Execute(func() { c.Close() })
+	go func() { _ = c.Close() }()
 }
 
 func (h *ProxyEventHandler) OnClose(c *nbio.Conn, err error) {

--- a/core/handler.go
+++ b/core/handler.go
@@ -51,9 +51,16 @@ type ConnContext struct {
 	// PROXY-v2-decoded source for a cross-region/trusted peer, NOT the relay. Proto
 	// and DstPort are set once at OnOpen; RealClientIP defaults to the peer and is
 	// upgraded to the parsed client when a trusted inbound PROXY-v2 header resolves.
-	Proto        string
-	DstPort      int
-	RealClientIP string
+	// PeerTrusted: the immediate peer is a trusted relay (its inbound PROXY-v2 header
+	// names the real client). ClientResolved: that header was actually parsed, so
+	// RealClientIP is the real client. When PeerTrusted && !ClientResolved we must NOT
+	// emit an L4 record — attributing it to the relay could get a peer-region relay
+	// scored/blocked (a cross-region outage).
+	Proto          string
+	DstPort        int
+	RealClientIP   string
+	PeerTrusted    bool
+	ClientResolved bool
 	// ProxyHeader, when non-nil, is prepended to each datagram written to
 	// PeerConn. Built once per session in connectBackendUDP when the
 	// backend has send_proxy_v2: true (or, for StripInbound conns, in OnData
@@ -109,13 +116,22 @@ func (h *ProxyEventHandler) OnOpen(c *nbio.Conn) {
 	}
 
 	dstPort := portOf(localAddr)
+	// Is the immediate peer a TRUSTED relay (cross-region)? Its inbound PROXY-v2
+	// header names the REAL client — but that isn't parsed until after the backend
+	// dial, so until then an L4 record can only carry the relay IP. Track it so the
+	// emit paths can suppress a relay-misattributed record (cross-region-outage risk).
+	peerTrusted := l.proxyTrust != nil && l.proxyTrust.trusts(c.RemoteAddr())
 
 	// Check rate limit
 	if rl, ok := h.engine.RateLimiters[l.Name]; ok {
 		if !rl.Allow() {
 			logging.Warn("[RATE] Connection from %s rejected (rate limit on %s)", c.RemoteAddr(), l.Name)
-			// L4 access record so ngris-sentinel sees the rejected flood (ratelimited→429).
-			logging.AccessL4(ipStrOf(c.RemoteAddr()), l.Protocol, dstPort, "ratelimited", 0, 0, 0)
+			// Attribute the rejection only when the peer IS the client (untrusted/direct).
+			// For a trusted relay the real client is unknowable here (no header parsed
+			// yet), so emitting would misattribute the relay — suppress it.
+			if !peerTrusted {
+				logging.AccessL4(ipStrOf(c.RemoteAddr()), l.Protocol, dstPort, "ratelimited", 0, 0, 0)
+			}
 			c.Close()
 			return
 		}
@@ -131,6 +147,7 @@ func (h *ProxyEventHandler) OnOpen(c *nbio.Conn) {
 		Proto:        l.Protocol,
 		DstPort:      dstPort,
 		RealClientIP: ipStrOf(c.RemoteAddr()), // upgraded to the PROXY-v2 client if a trusted header resolves
+		PeerTrusted:  peerTrusted,
 	}
 	h.setCtx(c, clientCtx)
 
@@ -152,6 +169,8 @@ func (h *ProxyEventHandler) OnClose(c *nbio.Conn, err error) {
 	proto := ctx.Proto
 	dstPort := ctx.DstPort
 	realClientIP := ctx.RealClientIP
+	peerTrusted := ctx.PeerTrusted
+	clientResolved := ctx.ClientResolved
 	ctx.PeerConn = nil // prevent double-close
 	ctx.Mu.Unlock()
 
@@ -168,15 +187,19 @@ func (h *ProxyEventHandler) OnClose(c *nbio.Conn, err error) {
 		logging.Info("[CONN] Closed %s (Dur: %v, Err: %v)", c.RemoteAddr(), time.Since(ctx.StartTime), err)
 		// L4 access record (mirrors AccessHTTP for HTTP). A backend was linked iff
 		// peer!=nil at close → "ok"; otherwise the connection never reached a backend
-		// (no active tunnel on the dialed port) → "no_route", the L4 analogue of a 404
-		// that drives ngris-sentinel's port-scan fan-out heuristic. Bytes are not
-		// accumulated in v1 (the heuristics key off port fan-out + status, not volume).
-		status := "no_route"
-		if peer != nil {
-			status = "ok"
+		// → "no_route" (the L4 analogue of a 404). Bytes are not accumulated in v1.
+		// SUPPRESS when the peer is a trusted relay whose real client we never resolved
+		// (connection died before its inbound PROXY-v2 header was read): attributing the
+		// record to the relay could get a peer-region relay scored/blocked. A direct
+		// (untrusted) peer IS the client, so it always emits.
+		if !peerTrusted || clientResolved {
+			status := "no_route"
+			if peer != nil {
+				status = "ok"
+			}
+			durMs := float64(time.Since(ctx.StartTime).Nanoseconds()) / 1e6
+			logging.AccessL4(realClientIP, proto, dstPort, status, 0, 0, durMs)
 		}
-		durMs := float64(time.Since(ctx.StartTime).Nanoseconds()) / 1e6
-		logging.AccessL4(realClientIP, proto, dstPort, status, 0, 0, durMs)
 		h.engine.ActiveConns.Done()
 	}
 }
@@ -203,7 +226,10 @@ func (h *ProxyEventHandler) OnData(c *nbio.Conn, data []byte) {
 			data = data[consumed:]
 			if src != nil {
 				ctx.Mu.Lock()
-				ctx.RealClientIP = ipStrOf(src) // the real UDP client (not the relay) for the L4 access record
+				if !ctx.ClientResolved { // set-once: the real UDP client (not the relay) for the L4 access record
+					ctx.RealClientIP = ipStrOf(src)
+					ctx.ClientResolved = true
+				}
 				if sendProxyV2 && ctx.ProxyHeader == nil {
 					var buf bytes.Buffer
 					if err := proxy.WriteProxyHeaderV2(&buf, src, localAddr); err == nil {
@@ -355,6 +381,7 @@ func (h *ProxyEventHandler) connectBackendTCP(clientConn *nbio.Conn, target stri
 		clientCtx.Mu.Lock()
 		clientCtx.PeerConn = backendConn
 		clientCtx.RealClientIP = ipStrOf(src) // the resolved client (PROXY-v2 source if trusted, else peer) for the L4 access record
+		clientCtx.ClientResolved = true       // real client is now known → the L4 record may be emitted
 
 		// Notify balancer
 		balancer.OnConnect(balancerKey)

--- a/core/handler.go
+++ b/core/handler.go
@@ -46,6 +46,14 @@ type ConnContext struct {
 	Buffer        []byte      // Buffer for data received before backend is connected
 	BackendServer string      // Original value from balancer.Next() (matches conns map key)
 	BalancerRef   lb.Balancer // Reference for OnDisconnect in OnClose
+	// L4 access logging (one record per connection at close, via logging.AccessL4):
+	// the protocol, the dialed (listener) port, and the REAL client — the
+	// PROXY-v2-decoded source for a cross-region/trusted peer, NOT the relay. Proto
+	// and DstPort are set once at OnOpen; RealClientIP defaults to the peer and is
+	// upgraded to the parsed client when a trusted inbound PROXY-v2 header resolves.
+	Proto        string
+	DstPort      int
+	RealClientIP string
 	// ProxyHeader, when non-nil, is prepended to each datagram written to
 	// PeerConn. Built once per session in connectBackendUDP when the
 	// backend has send_proxy_v2: true (or, for StripInbound conns, in OnData
@@ -100,22 +108,29 @@ func (h *ProxyEventHandler) OnOpen(c *nbio.Conn) {
 		return
 	}
 
+	dstPort := portOf(localAddr)
+
 	// Check rate limit
 	if rl, ok := h.engine.RateLimiters[l.Name]; ok {
 		if !rl.Allow() {
 			logging.Warn("[RATE] Connection from %s rejected (rate limit on %s)", c.RemoteAddr(), l.Name)
+			// L4 access record so ngris-sentinel sees the rejected flood (ratelimited→429).
+			logging.AccessL4(ipStrOf(c.RemoteAddr()), l.Protocol, dstPort, "ratelimited", 0, 0, 0)
 			c.Close()
 			return
 		}
 	}
 
-	logging.Info("[CONN] New %s client %s -> :%d", l.Protocol, c.RemoteAddr(), portOf(localAddr))
+	logging.Info("[CONN] New %s client %s -> :%d", l.Protocol, c.RemoteAddr(), dstPort)
 
 	h.engine.ActiveConns.Add(1)
 
 	clientCtx := &ConnContext{
-		IsBackend: false,
-		StartTime: time.Now(),
+		IsBackend:    false,
+		StartTime:    time.Now(),
+		Proto:        l.Protocol,
+		DstPort:      dstPort,
+		RealClientIP: ipStrOf(c.RemoteAddr()), // upgraded to the PROXY-v2 client if a trusted header resolves
 	}
 	h.setCtx(c, clientCtx)
 
@@ -134,6 +149,9 @@ func (h *ProxyEventHandler) OnClose(c *nbio.Conn, err error) {
 	backendServer := ctx.BackendServer
 	balancerRef := ctx.BalancerRef
 	isBackend := ctx.IsBackend
+	proto := ctx.Proto
+	dstPort := ctx.DstPort
+	realClientIP := ctx.RealClientIP
 	ctx.PeerConn = nil // prevent double-close
 	ctx.Mu.Unlock()
 
@@ -148,6 +166,17 @@ func (h *ProxyEventHandler) OnClose(c *nbio.Conn, err error) {
 
 	if !isBackend {
 		logging.Info("[CONN] Closed %s (Dur: %v, Err: %v)", c.RemoteAddr(), time.Since(ctx.StartTime), err)
+		// L4 access record (mirrors AccessHTTP for HTTP). A backend was linked iff
+		// peer!=nil at close → "ok"; otherwise the connection never reached a backend
+		// (no active tunnel on the dialed port) → "no_route", the L4 analogue of a 404
+		// that drives ngris-sentinel's port-scan fan-out heuristic. Bytes are not
+		// accumulated in v1 (the heuristics key off port fan-out + status, not volume).
+		status := "no_route"
+		if peer != nil {
+			status = "ok"
+		}
+		durMs := float64(time.Since(ctx.StartTime).Nanoseconds()) / 1e6
+		logging.AccessL4(realClientIP, proto, dstPort, status, 0, 0, durMs)
 		h.engine.ActiveConns.Done()
 	}
 }
@@ -172,9 +201,10 @@ func (h *ProxyEventHandler) OnData(c *nbio.Conn, data []byte) {
 	if stripInbound {
 		if src, consumed, isProxy := parseInboundProxyV2Datagram(data); isProxy {
 			data = data[consumed:]
-			if sendProxyV2 && src != nil {
+			if src != nil {
 				ctx.Mu.Lock()
-				if ctx.ProxyHeader == nil {
+				ctx.RealClientIP = ipStrOf(src) // the real UDP client (not the relay) for the L4 access record
+				if sendProxyV2 && ctx.ProxyHeader == nil {
 					var buf bytes.Buffer
 					if err := proxy.WriteProxyHeaderV2(&buf, src, localAddr); err == nil {
 						ctx.ProxyHeader = buf.Bytes()
@@ -324,6 +354,7 @@ func (h *ProxyEventHandler) connectBackendTCP(clientConn *nbio.Conn, target stri
 		// Link client to backend
 		clientCtx.Mu.Lock()
 		clientCtx.PeerConn = backendConn
+		clientCtx.RealClientIP = ipStrOf(src) // the resolved client (PROXY-v2 source if trusted, else peer) for the L4 access record
 
 		// Notify balancer
 		balancer.OnConnect(balancerKey)
@@ -555,6 +586,18 @@ func portOf(addr net.Addr) int {
 		return a.Port
 	}
 	return 0
+}
+
+// ipStrOf is the string form of the existing ipOf(addr) net.IP helper, "" when the
+// IP can't be resolved — used for the L4 access record's client field.
+func ipStrOf(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	if ip := ipOf(addr); ip != nil {
+		return ip.String()
+	}
+	return ""
 }
 
 // writeWithProxy writes data to peer, optionally prepending a PROXY v2

--- a/core/handler.go
+++ b/core/handler.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"nvelox/config"
+	"nvelox/core/denylist"
 	"nvelox/core/logging"
 	"nvelox/lb"
 	"nvelox/proxy"
@@ -137,6 +138,18 @@ func (h *ProxyEventHandler) OnOpen(c *nbio.Conn) {
 		}
 	}
 
+	// Dynamic denylist (sentinel-pushed runtime blocks): honor on the L4 accept
+	// path the same blocks the HTTP plane enforces (httpproxy Blocked() gate), so
+	// TCP and UDP drop blocked clients too. Enforced on the immediate peer only
+	// when it IS the client (untrusted/direct) — for a trusted relay the peer is
+	// infra and the real client isn't known until OnData parses PROXY-v2 (gated
+	// there). Mirrors the rate-limiter's peer-scoped enforcement above.
+	if h.l4Denied(c.RemoteAddr(), peerTrusted) {
+		logging.AccessL4(ipStrOf(c.RemoteAddr()), l.Protocol, dstPort, "denylisted", 0, 0, 0)
+		c.Close()
+		return
+	}
+
 	logging.Info("[CONN] New %s client %s -> :%d", l.Protocol, c.RemoteAddr(), dstPort)
 
 	h.engine.ActiveConns.Add(1)
@@ -152,6 +165,19 @@ func (h *ProxyEventHandler) OnOpen(c *nbio.Conn) {
 	h.setCtx(c, clientCtx)
 
 	h.connectBackend(c, l)
+}
+
+// l4Denied reports whether an L4 (TCP/UDP) connection from addr must be dropped
+// by the dynamic denylist. Only the immediate peer is consulted, and only when
+// it is the real client (untrusted/direct): a trusted relay's peer IS infra, so
+// blocking it would sever cross-region traffic — the real client behind such a
+// relay is enforced in OnData once PROXY-v2 resolves it.
+func (h *ProxyEventHandler) l4Denied(addr net.Addr, peerTrusted bool) bool {
+	if peerTrusted || addr == nil {
+		return false
+	}
+	ip := ipOf(addr)
+	return ip != nil && denylist.Default.Blocked(ip)
 }
 
 func (h *ProxyEventHandler) OnClose(c *nbio.Conn, err error) {
@@ -220,15 +246,24 @@ func (h *ProxyEventHandler) OnData(c *nbio.Conn, data []byte) {
 	stripInbound := ctx.StripInbound
 	sendProxyV2 := ctx.SendProxyV2
 	localAddr := ctx.LocalAddr
+	proto := ctx.Proto
+	dstPort := ctx.DstPort
 	ctx.Mu.Unlock()
 	if stripInbound {
 		if src, consumed, isProxy := parseInboundProxyV2Datagram(data); isProxy {
 			data = data[consumed:]
 			if src != nil {
+				resolvedBlocked := false
 				ctx.Mu.Lock()
 				if !ctx.ClientResolved { // set-once: the real UDP client (not the relay) for the L4 access record
 					ctx.RealClientIP = ipStrOf(src)
 					ctx.ClientResolved = true
+					// Dynamic denylist on the REAL client behind a trusted relay
+					// (cross-region UDP): the OnOpen peer gate only saw the relay,
+					// so enforce here, once, when the client is first resolved.
+					if ip := ipOf(src); ip != nil {
+						resolvedBlocked = denylist.Default.Blocked(ip)
+					}
 				}
 				if sendProxyV2 && ctx.ProxyHeader == nil {
 					var buf bytes.Buffer
@@ -239,6 +274,11 @@ func (h *ProxyEventHandler) OnData(c *nbio.Conn, data []byte) {
 					}
 				}
 				ctx.Mu.Unlock()
+				if resolvedBlocked {
+					logging.AccessL4(ipStrOf(src), proto, dstPort, "denylisted", 0, 0, 0)
+					c.Close()
+					return
+				}
 			}
 		}
 	}

--- a/core/handler.go
+++ b/core/handler.go
@@ -133,7 +133,7 @@ func (h *ProxyEventHandler) OnOpen(c *nbio.Conn) {
 			if !peerTrusted {
 				logging.AccessL4(ipStrOf(c.RemoteAddr()), l.Protocol, dstPort, "ratelimited", 0, 0, 0)
 			}
-			c.Close()
+			closeOnOpen(c)
 			return
 		}
 	}
@@ -146,7 +146,7 @@ func (h *ProxyEventHandler) OnOpen(c *nbio.Conn) {
 	// there). Mirrors the rate-limiter's peer-scoped enforcement above.
 	if h.l4Denied(c.RemoteAddr(), peerTrusted) {
 		logging.AccessL4(ipStrOf(c.RemoteAddr()), l.Protocol, dstPort, "denylisted", 0, 0, 0)
-		c.Close()
+		closeOnOpen(c)
 		return
 	}
 
@@ -178,6 +178,18 @@ func (h *ProxyEventHandler) l4Denied(addr net.Addr, peerTrusted bool) bool {
 	}
 	ip := ipOf(addr)
 	return ip != nil && denylist.Default.Blocked(ip)
+}
+
+// closeOnOpen closes a connection being REJECTED from OnOpen (rate-limit or
+// denylist). It must NOT call c.Close() directly: nbio's addConn calls OnOpen and
+// only AFTER it returns registers the fd with the poller (addRead). Closing the
+// fd synchronously inside OnOpen makes that addRead fail with EBADF ("addConn
+// failed: bad file descriptor") and, under fd reuse, can orphan a reused fd — a
+// leaked connection that never gets served and lingers until timeout. Conn.Execute
+// defers the close onto the engine job pool, which runs after addConn has finished
+// — the nbio-intended pattern for post-callback work on a connection.
+func closeOnOpen(c *nbio.Conn) {
+	c.Execute(func() { c.Close() })
 }
 
 func (h *ProxyEventHandler) OnClose(c *nbio.Conn, err error) {

--- a/core/handler_l4denylist_test.go
+++ b/core/handler_l4denylist_test.go
@@ -1,0 +1,72 @@
+package core
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"nvelox/core/denylist"
+)
+
+// TestL4Denied verifies the L4 (TCP/UDP) accept-path denylist gate: a direct
+// client whose IP is on the dynamic denylist is dropped, a clean IP passes, and
+// a trusted relay's peer IP is never dropped (its real client is enforced in
+// OnData). This mirrors the HTTP plane's Blocked() gate onto TCP/UDP.
+func TestL4Denied(t *testing.T) {
+	h := &ProxyEventHandler{}
+
+	const blockedIP = "203.0.113.7"
+	tcpBlocked := &net.TCPAddr{IP: net.ParseIP(blockedIP), Port: 40000}
+	udpBlocked := &net.UDPAddr{IP: net.ParseIP(blockedIP), Port: 53}
+	tcpClean := &net.TCPAddr{IP: net.ParseIP("203.0.113.9"), Port: 40000}
+
+	// Clean denylist: nothing is denied.
+	if h.l4Denied(tcpBlocked, false) {
+		t.Fatalf("with empty denylist, %s must not be denied", blockedIP)
+	}
+
+	if _, err := denylist.Default.Add(blockedIP, time.Hour); err != nil {
+		t.Fatalf("seed denylist: %v", err)
+	}
+	defer denylist.Default.Remove(blockedIP)
+
+	if !h.l4Denied(tcpBlocked, false) {
+		t.Errorf("blocked TCP client %s must be denied", blockedIP)
+	}
+	if !h.l4Denied(udpBlocked, false) {
+		t.Errorf("blocked UDP client %s must be denied", blockedIP)
+	}
+	if h.l4Denied(tcpClean, false) {
+		t.Errorf("unblocked client must pass")
+	}
+	// A trusted relay's peer is infra, not the client — never deny on the peer IP
+	// even if (pathologically) it appears on the list; the real client is gated
+	// in OnData after PROXY-v2 resolution.
+	if h.l4Denied(tcpBlocked, true) {
+		t.Errorf("trusted-relay peer must not be denied on the peer IP")
+	}
+	// A nil/unresolved address must not panic and must not deny.
+	if h.l4Denied(nil, false) {
+		t.Errorf("nil addr must not be denied")
+	}
+}
+
+// TestL4DeniedExpiry confirms an expired block no longer denies (TTL-aware).
+func TestL4DeniedExpiry(t *testing.T) {
+	h := &ProxyEventHandler{}
+	const ip = "203.0.113.11"
+	addr := &net.TCPAddr{IP: net.ParseIP(ip), Port: 1}
+
+	if _, err := denylist.Default.Add(ip, 20*time.Millisecond); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	defer denylist.Default.Remove(ip)
+
+	if !h.l4Denied(addr, false) {
+		t.Fatalf("freshly-blocked %s must be denied", ip)
+	}
+	time.Sleep(40 * time.Millisecond)
+	if h.l4Denied(addr, false) {
+		t.Errorf("expired block for %s must no longer deny", ip)
+	}
+}

--- a/core/httpproxy/server.go
+++ b/core/httpproxy/server.go
@@ -769,7 +769,7 @@ func (s *HTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	duration := float64(time.Since(start).Microseconds()) / 1000.0
-	logging.AccessHTTP(clientIP, r.Host, r.Method, r.URL.Path, r.Proto, rec.status, rec.bytes, duration, lastTarget)
+	logging.AccessHTTP(clientIP, r.Host, r.Method, r.URL.Path, r.Proto, rec.status, rec.bytes, duration, lastTarget, r.UserAgent())
 }
 
 // getStickyKey returns the session key based on the sticky session config.

--- a/core/logging/logger.go
+++ b/core/logging/logger.go
@@ -189,6 +189,25 @@ func AccessHTTP(clientIP, host, method, path, proto string, status int, bytes in
 		SanitizeLogField(backend))
 }
 
+// AccessL4 logs one raw TCP/UDP connection (or rejection) to the SAME access log
+// as AccessHTTP, so the existing shipper/queue/consumer pick it up unchanged. The
+// ` - l4 ` marker distinguishes it from an HTTP record:
+//
+//	<clientIP> - l4 <proto>/<dstPort> <status> <bytesIn> <bytesOut> <durMs>ms
+//	  e.g. 203.0.113.5 - l4 tcp/7000 no_route 0 0 0.400ms
+//
+// clientIP MUST be the real client (the PROXY-protocol-decoded source for
+// cross-region, not the relay). proto is "tcp"|"udp"; status is a short token
+// (ok|no_route|refused|ratelimited|timeout|error). Fields are CRLF-sanitized.
+func AccessL4(clientIP, proto string, dstPort int, status string, bytesIn, bytesOut int64, durationMs float64) {
+	current.Load().accessLog.Printf("%s - l4 %s/%d %s %d %d %.3fms",
+		SanitizeLogField(clientIP),
+		SanitizeLogField(proto),
+		dstPort,
+		SanitizeLogField(status),
+		bytesIn, bytesOut, durationMs)
+}
+
 func Fatal(format string, v ...interface{}) {
 	current.Load().errorLog.Output(2, fmt.Sprintf("[FATAL] "+format, v...))
 	os.Exit(1)

--- a/core/logging/logger.go
+++ b/core/logging/logger.go
@@ -8,7 +8,29 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"unicode/utf8"
 )
+
+// maxUALogLen bounds the User-Agent written to the access log. The UA is
+// attacker-controlled and effectively only capped by the server's max header size
+// (~1MB), so without a clip a single request could emit a multi-KB log line. Because
+// the UA is the LAST field, an oversized line that a downstream shipper truncates
+// would lose its closing quote and corrupt the record — an attacker could pad their UA
+// to push their own request past the shipper's per-line limit and evade log-based
+// detection entirely. 512 bytes is ample for any legitimate UA.
+const maxUALogLen = 512
+
+// clipUA bounds s to at most maxUALogLen bytes without splitting a UTF-8 rune.
+func clipUA(s string) string {
+	if len(s) <= maxUALogLen {
+		return s
+	}
+	cut := maxUALogLen
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
+}
 
 type Level int
 
@@ -175,18 +197,22 @@ func SanitizeLogField(s string) string {
 // no-op; we do it anyway as defense-in-depth against future callers passing a
 // less-validated value. host is the requested vhost (r.Host); an empty host is
 // logged as "-".
-func AccessHTTP(clientIP, host, method, path, proto string, status int, bytes int64, duration float64, backend string) {
+func AccessHTTP(clientIP, host, method, path, proto string, status int, bytes int64, duration float64, backend, userAgent string) {
 	if host == "" {
 		host = "-"
 	}
-	current.Load().accessLog.Printf("%s - %s \"%s %s %s\" %d %d %.3fms -> %s",
+	// User-Agent is appended LAST as a quoted field so a consumer can make it optional
+	// and stay back-compatible with the old (UA-less) format. CRLF-sanitized like the
+	// rest; the UA is attacker-controlled.
+	current.Load().accessLog.Printf("%s - %s \"%s %s %s\" %d %d %.3fms -> %s \"%s\"",
 		SanitizeLogField(clientIP),
 		SanitizeLogField(host),
 		SanitizeLogField(method),
 		SanitizeLogField(path),
 		SanitizeLogField(proto),
 		status, bytes, duration,
-		SanitizeLogField(backend))
+		SanitizeLogField(backend),
+		SanitizeLogField(clipUA(userAgent)))
 }
 
 // AccessL4 logs one raw TCP/UDP connection (or rejection) to the SAME access log

--- a/core/logging/logging_test.go
+++ b/core/logging/logging_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestInit(t *testing.T) {
@@ -114,11 +115,12 @@ func TestAccessHTTP_LogInjection(t *testing.T) {
 		t.Fatalf("Init failed: %v", err)
 	}
 
-	// Attacker-controlled path AND Host header both try to inject a fake
-	// log entry — both must be sanitized.
+	// Attacker-controlled path, Host header AND User-Agent all try to inject a
+	// fake log entry — all must be sanitized.
 	evilPath := "/legit\n10.0.0.1 - \"GET /admin HTTP/1.1\" 200 0 0.000ms -> backend"
 	evilHost := "victim.example\nINJECTED"
-	AccessHTTP("1.2.3.4", evilHost, "GET", evilPath, "HTTP/1.1", 200, 0, 0.1, "upstream:80")
+	evilUA := "sqlmap/1.5\nINJECTED-VIA-UA"
+	AccessHTTP("1.2.3.4", evilHost, "GET", evilPath, "HTTP/1.1", 200, 0, 0.1, "upstream:80", evilUA)
 
 	content, err := os.ReadFile(accessPath)
 	if err != nil {
@@ -133,6 +135,26 @@ func TestAccessHTTP_LogInjection(t *testing.T) {
 	}
 	if !strings.Contains(s, "\\n10.0.0.1") {
 		t.Errorf("expected escaped '\\n10.0.0.1' in sanitized output, got: %q", s)
+	}
+}
+
+// TestAccessHTTP_UAClipped verifies the attacker-controlled User-Agent is length-bounded
+// (so a multi-KB UA can't blow up the log line and risk shipper truncation) and the clip
+// is rune-safe (never splits a UTF-8 sequence).
+func TestAccessHTTP_UAClipped(t *testing.T) {
+	// Multi-byte runes (é = 2 bytes) so a naive byte-cut could split one.
+	hugeUA := strings.Repeat("é", 4000) // 8000 bytes
+	got := clipUA(hugeUA)
+	if len(got) > maxUALogLen {
+		t.Errorf("clipUA len=%d want <= %d", len(got), maxUALogLen)
+	}
+	if !utf8.ValidString(got) {
+		t.Errorf("clipUA produced invalid UTF-8 (split a rune)")
+	}
+	// A normal-length UA is returned unchanged.
+	const normal = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
+	if clipUA(normal) != normal {
+		t.Errorf("clipUA mutated a normal UA")
 	}
 }
 

--- a/core/logging/logging_test.go
+++ b/core/logging/logging_test.go
@@ -87,15 +87,15 @@ func TestSanitizeLogField(t *testing.T) {
 		in, want string
 	}{
 		{"", ""},
-		{"/api/v1/users", "/api/v1/users"},                                // clean ASCII fast path
-		{"/path\nINJECTED", "/path\\nINJECTED"},                           // LF → \n literal
-		{"/path\rINJECTED", "/path\\rINJECTED"},                           // CR → \r literal
-		{"/path\tINJECTED", "/path\\tINJECTED"},                           // TAB → \t literal
-		{"/path\r\nGET /secret", "/path\\r\\nGET /secret"},                // CRLF attack
-		{"/path\x00\x01\x02", "/path???"},                                 // other controls → ?
-		{"/path\x7f", "/path?"},                                           // DEL → ?
-		{"normal text with space", "normal text with space"},              // space preserved
-		{"unicode ☃ éclair", "unicode ☃ éclair"},                          // multibyte UTF-8 preserved
+		{"/api/v1/users", "/api/v1/users"},                   // clean ASCII fast path
+		{"/path\nINJECTED", "/path\\nINJECTED"},              // LF → \n literal
+		{"/path\rINJECTED", "/path\\rINJECTED"},              // CR → \r literal
+		{"/path\tINJECTED", "/path\\tINJECTED"},              // TAB → \t literal
+		{"/path\r\nGET /secret", "/path\\r\\nGET /secret"},   // CRLF attack
+		{"/path\x00\x01\x02", "/path???"},                    // other controls → ?
+		{"/path\x7f", "/path?"},                              // DEL → ?
+		{"normal text with space", "normal text with space"}, // space preserved
+		{"unicode ☃ éclair", "unicode ☃ éclair"},             // multibyte UTF-8 preserved
 	}
 	for _, c := range cases {
 		got := SanitizeLogField(c.in)
@@ -133,6 +133,26 @@ func TestAccessHTTP_LogInjection(t *testing.T) {
 	}
 	if !strings.Contains(s, "\\n10.0.0.1") {
 		t.Errorf("expected escaped '\\n10.0.0.1' in sanitized output, got: %q", s)
+	}
+}
+
+// TestAccessL4_Format locks the L4 access-line format to exactly what the
+// ngris-sentinel parser (l4Re) expects: "<ip> - l4 <proto>/<port> <status> <in> <out> <durMs>ms".
+func TestAccessL4_Format(t *testing.T) {
+	tmpDir := t.TempDir()
+	accessPath := filepath.Join(tmpDir, "access.log")
+	if err := Init("debug", accessPath, ""); err != nil {
+		t.Fatalf("Init failed: %v", err)
+	}
+	AccessL4("203.0.113.5", "tcp", 7000, "no_route", 0, 0, 0.4)
+	content, err := os.ReadFile(accessPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got := strings.TrimRight(string(content), "\n")
+	want := "203.0.113.5 - l4 tcp/7000 no_route 0 0 0.400ms"
+	if got != want {
+		t.Errorf("AccessL4 line = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
Emit one access-log record per raw TCP/UDP connection, in the **same access log**
  as the HTTP records, so the edge-log abuse-detection worker (ngris-sentinel) can
  score L4 sources — covering the **L4-only regional edge**, which produces no HTTP logs.
 
  - `logging.AccessL4`: `<ip> - l4 <proto>/<dstPort> <status> <in> <out> <durMs>ms`
    (status `ok|no_route|refused|ratelimited|timeout|error`), CRLF-sanitized.
    `TestAccessL4_Format` locks the line format.
  - `handler`: `ConnContext` carries proto/dstPort and the **real client** (PROXY-v2-
    decoded for a trusted peer, not the relay); emitted at connection close (`ok` vs
    `no_route` from whether a backend was linked) and on rate-limit reject (`ratelimited`).
  - Bytes not accumulated in v1 (emit `0`); the consumer keys off port fan-out + status.

  ## Why
  The L4 record maps cleanly onto ngris-sentinel's existing event model
  (`path="<proto>/<port>"`, synthetic status), so a tunnel-port-range scan trips its
  fan-out heuristic and a rate-limited flood trips its noisy heuristic — no new scoring
  logic. Enforcement is already protocol-agnostic (the IP denylist).

  ## Lockstep / status
  - Pairs with the ngris-sentinel L4 parser (must ship together).
  - `build`/`vet`/`go test ./core/... ./core/logging/...` green.
  - ⚠️  The handler wiring touches the nbio event loop and is **not yet runtime-tested**;
    needs runtime validation before a release.
  - ⚠️  Cross-region attribution (rate-limited / pre-PROXY-parse connections logging the
    relay IP) is under adversarial review; follow-up commits may land on this branch.

